### PR TITLE
add time expiry and rename nft_vote_ticket

### DIFF
--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/error.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/error.rs
@@ -80,33 +80,15 @@ pub enum NftVoterError {
     #[msg("Invalid Vote Record Account")]
     InvalidVoteRecordAccount,
 
-    #[msg("Leaf Owner Must Be Payer")]
-    LeafOwnerMustBePayer,
-
-    #[msg("Leaf Owner Must Be Token Owner")]
-    LeafOwnerMustBeTokenOwner,
-
-    #[msg("Invalid Metadata")]
-    InvalidMetadata,
-
-    #[msg("Invalid AssetId")]
-    InvalidAssetId,
-
-    #[msg("Invalid NFT Collection")]
-    InvalidCollectionMint,
-
     #[msg("Governance Token Owner Or Delegate Must Sign")]
     GoverningTokenOwnerOrDelegateMustSign,
-
-    #[msg("Leaf Owner Must Be Voter Authority")]
-    LeafOwnerMustBeVoterAuthority,
-
-    #[msg("Account Data Not Empty")]
-    AccountDataNotEmpty,
 
     #[msg("NFT Failed Verification")]
     NftFailedVerification,
 
-    #[msg("Invalid PDA Owner")]
-    InvalidPdaOwner,
+    #[msg("Nft Ticket Expired")]
+    NftTicketExpired,
+
+    #[msg("Voter With Invalid Ticket")]
+    InvalidNftTicket,
 }

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/instructions/create_nft_action_ticket.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/instructions/create_nft_action_ticket.rs
@@ -1,6 +1,6 @@
 use crate::error::NftVoterError;
 use crate::state::*;
-use crate::tools::accounts::create_nft_vote_ticket_account;
+use crate::tools::accounts::create_nft_action_ticket_account;
 use anchor_lang::prelude::*;
 use itertools::Itertools;
 
@@ -15,7 +15,7 @@ use itertools::Itertools;
 /// This is the instruction for verifying NFT.
 #[derive(Accounts)]
 #[instruction(voter_weight_action:VoterWeightAction)]
-pub struct CreateNftVoteTicket<'info> {
+pub struct CreateNftActionTicket<'info> {
     pub registrar: Account<'info, Registrar>,
 
     #[account(
@@ -33,8 +33,8 @@ pub struct CreateNftVoteTicket<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn create_nft_vote_ticket<'info>(
-    ctx: Context<'_, '_, '_, 'info, CreateNftVoteTicket<'info>>,
+pub fn create_nft_action_ticket<'info>(
+    ctx: Context<'_, '_, '_, 'info, CreateNftActionTicket<'info>>,
     voter_weight_action: VoterWeightAction
 ) -> Result<()> {
     let registrar = &ctx.accounts.registrar;
@@ -44,10 +44,9 @@ pub fn create_nft_vote_ticket<'info>(
     let mut unique_nft_mints: Vec<Pubkey> = vec![];
     let ticket_type = format!("nft-{}-ticket", &voter_weight_action).to_string();
 
-    for (nft_info, nft_metadata_info, nft_vote_ticket_info) in ctx.remaining_accounts
+    for (nft_info, nft_metadata_info, nft_action_ticket_info) in ctx.remaining_accounts
         .iter()
         .tuples() {
-        require!(nft_vote_ticket_info.data_is_empty(), NftVoterError::AccountDataNotEmpty);
         let (nft_vote_weight, nft_mint) = resolve_nft_vote_weight_and_mint(
             registrar,
             &governing_token_owner,
@@ -56,31 +55,34 @@ pub fn create_nft_vote_ticket<'info>(
             &mut unique_nft_mints
         )?;
 
-        create_nft_vote_ticket_account(
-            payer,
-            &nft_vote_ticket_info,
-            &registrar.key().clone(),
-            &governing_token_owner.key().clone(),
-            &nft_mint,
-            &ticket_type,
-            system_program
-        )?;
-        let serialized_data = NftVoteTicket {
-            account_discriminator: NftVoteTicket::ACCOUNT_DISCRIMINATOR,
+        if nft_action_ticket_info.data_is_empty() {
+            create_nft_action_ticket_account(
+                payer,
+                &nft_action_ticket_info,
+                &registrar.key().clone(),
+                &governing_token_owner.key().clone(),
+                &nft_mint,
+                &ticket_type,
+                system_program
+            )?;
+        }
+        let serialized_data = NftActionTicket {
+            account_discriminator: NftActionTicket::ACCOUNT_DISCRIMINATOR,
             registrar: registrar.key().clone(),
             governing_token_owner: governing_token_owner.clone(),
             nft_mint: nft_mint.clone(),
             weight: nft_vote_weight,
+            expiry: Some(Clock::get()?.slot + 10),
         };
         // CHECK: if this is this should not be a function, but merge the code into this instruction
         // make this instruction the only method that can serizlize the data
         // so in cast_nft_vote can check if the data is all zero
-        // serialize_nft_vote_ticket_account(
+        // serialize_nft_action_ticket_account(
         //     &serialized_data.try_to_vec()?,
-        //     &nft_vote_ticket_info
+        //     &nft_action_ticket_info
         // )?;
 
-        nft_vote_ticket_info.data.borrow_mut().copy_from_slice(&serialized_data.try_to_vec()?);
+        nft_action_ticket_info.data.borrow_mut().copy_from_slice(&serialized_data.try_to_vec()?);
     }
 
     Ok(())

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/instructions/mod.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/instructions/mod.rs
@@ -19,8 +19,8 @@ mod relinquish_nft_vote;
 pub use cast_nft_vote::*;
 mod cast_nft_vote;
 
-pub use create_cnft_vote_ticket::*;
-mod create_cnft_vote_ticket;
+pub use create_cnft_action_ticket::*;
+mod create_cnft_action_ticket;
 
-pub use create_nft_vote_ticket::*;
-mod create_nft_vote_ticket;
+pub use create_nft_action_ticket::*;
+mod create_nft_action_ticket;

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/lib.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/lib.rs
@@ -62,21 +62,21 @@ pub mod nft_voter {
         instructions::cast_nft_vote(ctx, proposal)
     }
 
-    pub fn create_nft_vote_ticket<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, CreateNftVoteTicket<'info>>,
+    pub fn create_nft_action_ticket<'a, 'b, 'c, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, CreateNftActionTicket<'info>>,
         voter_weight_action: VoterWeightAction
     ) -> Result<()> {
         log_version();
-        instructions::create_nft_vote_ticket(ctx, voter_weight_action)
+        instructions::create_nft_action_ticket(ctx, voter_weight_action)
     }
 
-    pub fn create_cnft_vote_ticket<'a, 'b, 'c, 'info>(
-        ctx: Context<'a, 'b, 'c, 'info, CreateCnftVoteTicket<'info>>,
+    pub fn create_cnft_action_ticket<'a, 'b, 'c, 'info>(
+        ctx: Context<'a, 'b, 'c, 'info, CreateCnftActionTicket<'info>>,
         voter_weight_action: VoterWeightAction,
         params: Vec<CompressedNftAsset>
     ) -> Result<()> {
         log_version();
-        instructions::create_cnft_vote_ticket(ctx, voter_weight_action, params)
+        instructions::create_cnft_action_ticket(ctx, voter_weight_action, params)
     }
 }
 

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/state/idl_types.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/state/idl_types.rs
@@ -17,9 +17,10 @@ pub struct NftVoteRecord {
 }
 
 #[account]
-pub struct NftVoteTicket {
+pub struct NftActionTicket {
     pub registrar: Pubkey,
     pub governing_token_owner: Pubkey,
     pub nft_mint: Pubkey,
     pub weight: u64,
+    pub expiry: Option<u64>,
 }

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/state/mod.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/state/mod.rs
@@ -15,7 +15,7 @@ pub mod voter_weight_record;
 pub use cnft_verification::*;
 pub mod cnft_verification;
 
-pub use nft_vote_ticket::*;
-pub mod nft_vote_ticket;
+pub use nft_action_ticket::*;
+pub mod nft_action_ticket;
 
 pub mod idl_types;

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/state/nft_action_ticket.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/state/nft_action_ticket.rs
@@ -4,31 +4,39 @@ use borsh::{ BorshDeserialize, BorshSchema, BorshSerialize };
 use solana_program::program_pack::IsInitialized;
 use spl_governance_tools::account::{ get_account_data, AccountMaxSize };
 
-pub const NFT_VOTE_TICKET_SIZE: usize = DISCRIMINATOR_SIZE + 32 + 32 + 32 + 8;
+pub const NFT_ACTION_TICKET_SIZE: usize = DISCRIMINATOR_SIZE + 32 + 32 + 32 + 8 + 1 + 8;
 
 // maybe should moce the nft_owner as part of the seeds
 // so that if the owner transfer the nft to new owner, otherwise
-// require!(data.nft_owner == governing_token_owner, NftVoterError::VoterDoesNotOwnNft); will fail
+// require!(data.nft_owner == governing_token_owner, NftVoterError::InvalidNftTicket); will fail
 // and instead to store nft_owner or weight, perhaps should store to-be-verified data?
 // or maybe not? cuz the no-matter the sybil attack exist that nft-owner keep transfer and vot
 // nft_vote_record.data_is_empty() will still block the second vote with the same nft
 #[derive(Clone, Debug, PartialEq, BorshDeserialize, BorshSerialize, BorshSchema)]
-pub struct NftVoteTicket {
+pub struct NftActionTicket {
     pub account_discriminator: [u8; 8],
     pub registrar: Pubkey,
     pub governing_token_owner: Pubkey,
     pub nft_mint: Pubkey,
     pub weight: u64,
+    pub expiry: Option<u64>,
 }
 
-impl NftVoteTicket {
-    pub fn new(registrar: Pubkey, owner: Pubkey, nft_mint: Pubkey, weight: u64) -> Self {
+impl NftActionTicket {
+    pub fn new(
+        registrar: Pubkey,
+        owner: Pubkey,
+        nft_mint: Pubkey,
+        weight: u64,
+        expiry: Option<u64>
+    ) -> Self {
         Self {
-            account_discriminator: NftVoteTicket::ACCOUNT_DISCRIMINATOR,
-            registrar: registrar,
+            account_discriminator: NftActionTicket::ACCOUNT_DISCRIMINATOR,
+            registrar,
             governing_token_owner: owner,
-            nft_mint: nft_mint,
+            nft_mint,
             weight,
+            expiry,
         }
     }
 
@@ -37,24 +45,24 @@ impl NftVoteTicket {
     }
 }
 
-impl NftVoteTicket {
-    /// sha256("account:NftVoteTicket")
+impl NftActionTicket {
+    /// sha256("account:NftActionTicket")
     /// python:
     /// from hashlib import sha256
-    /// list(sha256("account:NftVoteTicket".encode()).digest())[:8]
+    /// list(sha256("account:NftActionTicket".encode()).digest())[:8]
     pub const ACCOUNT_DISCRIMINATOR: [u8; 8] = [170, 179, 4, 130, 24, 148, 185, 97];
 }
 
-impl AccountMaxSize for NftVoteTicket {}
+impl AccountMaxSize for NftActionTicket {}
 
-impl IsInitialized for NftVoteTicket {
+impl IsInitialized for NftActionTicket {
     fn is_initialized(&self) -> bool {
-        self.account_discriminator == NftVoteTicket::ACCOUNT_DISCRIMINATOR
+        self.account_discriminator == NftActionTicket::ACCOUNT_DISCRIMINATOR
     }
 }
 
 /// ticket_type = format!("nft-{}-ticket", &voter_weight_action).to_string();
-pub fn get_nft_vote_ticket_seeds<'a>(
+pub fn get_nft_action_ticket_seeds<'a>(
     ticket_type: &'a str,
     registrar: &'a Pubkey,
     owner: &'a Pubkey,
@@ -63,18 +71,18 @@ pub fn get_nft_vote_ticket_seeds<'a>(
     [&ticket_type.as_bytes(), registrar.as_ref(), owner.as_ref(), nft_mint.as_ref()]
 }
 
-pub fn get_nft_vote_ticket_address(
+pub fn get_nft_action_ticket_address(
     ticket_type: &str,
     registrar: &Pubkey,
     owner: &Pubkey,
     nft_mint: &Pubkey
 ) -> (Pubkey, u8) {
     Pubkey::find_program_address(
-        &get_nft_vote_ticket_seeds(ticket_type, registrar, owner, nft_mint),
+        &get_nft_action_ticket_seeds(ticket_type, registrar, owner, nft_mint),
         &crate::id()
     )
 }
 
-pub fn get_nft_vote_ticket_data(nft_vote_ticket_info: &AccountInfo) -> Result<NftVoteTicket> {
-    Ok(get_account_data::<NftVoteTicket>(&crate::id(), nft_vote_ticket_info)?)
+pub fn get_nft_action_ticket_data(nft_vote_ticket_info: &AccountInfo) -> Result<NftActionTicket> {
+    Ok(get_account_data::<NftActionTicket>(&crate::id(), nft_vote_ticket_info)?)
 }

--- a/cNft-Governance/governance-program-library/programs/nft-voter/src/tools/accounts.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/src/tools/accounts.rs
@@ -8,7 +8,7 @@ use solana_program::program::invoke_signed;
 use solana_program::msg;
 use crate::state::*;
 
-pub fn create_nft_vote_ticket_account<'a>(
+pub fn create_nft_action_ticket_account<'a>(
     payer: &AccountInfo<'a>,
     account_info: &AccountInfo<'a>,
     registrar: &Pubkey,
@@ -17,8 +17,13 @@ pub fn create_nft_vote_ticket_account<'a>(
     ticket_type: &str,
     system_program: &AccountInfo<'a>
 ) -> Result<(), ProgramError> {
-    let account_address_seeds = get_nft_vote_ticket_seeds(ticket_type, registrar, owner, nft_mint);
-    let (account_address, bump_seed) = get_nft_vote_ticket_address(
+    let account_address_seeds = get_nft_action_ticket_seeds(
+        ticket_type,
+        registrar,
+        owner,
+        nft_mint
+    );
+    let (account_address, bump_seed) = get_nft_action_ticket_address(
         ticket_type,
         registrar,
         owner,
@@ -36,7 +41,7 @@ pub fn create_nft_vote_ticket_account<'a>(
 
     let rent = Rent::get()?;
 
-    let lamports = rent.minimum_balance(NFT_VOTE_TICKET_SIZE);
+    let lamports = rent.minimum_balance(NFT_ACTION_TICKET_SIZE);
     let mut signers_seeds = account_address_seeds.to_vec();
     let bump = &[bump_seed];
     signers_seeds.push(bump);
@@ -45,7 +50,7 @@ pub fn create_nft_vote_ticket_account<'a>(
         payer.key,
         &account_address,
         lamports,
-        NFT_VOTE_TICKET_SIZE as u64,
+        NFT_ACTION_TICKET_SIZE as u64,
         &crate::id()
     );
 
@@ -57,7 +62,7 @@ pub fn create_nft_vote_ticket_account<'a>(
     Ok(())
 }
 
-pub fn serialize_nft_vote_ticket_account(
+pub fn serialize_nft_action_ticket_account(
     serialized_data: &Vec<u8>,
     account_info: &AccountInfo
 ) -> Result<(), ProgramError> {
@@ -65,7 +70,7 @@ pub fn serialize_nft_vote_ticket_account(
     Ok(())
 }
 
-pub fn close_nft_vote_ticket_account(
+pub fn close_nft_action_ticket_account(
     account_info: &AccountInfo,
     beneficiary_info: &AccountInfo
 ) -> Result<(), ProgramError> {

--- a/cNft-Governance/governance-program-library/programs/nft-voter/tests/cast_vote.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/tests/cast_vote.rs
@@ -49,7 +49,7 @@ async fn test_cast_nft_vote_with_nft() -> Result<(), TransportError> {
     let clock = nft_voter_test.bench.get_clock().await;
 
     let action = VoterWeightAction::CastVote;
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -64,7 +64,7 @@ async fn test_cast_nft_vote_with_nft() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -83,10 +83,10 @@ async fn test_cast_nft_vote_with_nft() -> Result<(), TransportError> {
     assert_eq!(voter_weight_record.weight_action, Some(VoterWeightAction::CastVote.into()));
     assert_eq!(voter_weight_record.weight_action_target, Some(proposal_cookie.address));
 
-    let nft_vote_ticket_address = nft_vote_ticket_cookies[0].address;
-    let nft_vote_ticket = nft_voter_test.bench.get_account(&nft_vote_ticket_address).await;
+    let nft_action_ticket_address = nft_action_ticket_cookies[0].address;
+    let nft_action_ticket = nft_voter_test.bench.get_account(&nft_action_ticket_address).await;
 
-    assert_eq!(None, nft_vote_ticket);
+    assert_eq!(None, nft_action_ticket);
 
     Ok(())
 }
@@ -143,7 +143,7 @@ async fn test_cast_nft_vote_with_cnft() -> Result<(), TransportError> {
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -160,7 +160,7 @@ async fn test_cast_nft_vote_with_cnft() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -178,10 +178,10 @@ async fn test_cast_nft_vote_with_cnft() -> Result<(), TransportError> {
     assert_eq!(voter_weight_record.weight_action, Some(VoterWeightAction::CastVote.into()));
     assert_eq!(voter_weight_record.weight_action_target, Some(proposal_cookie.address));
 
-    let cnft_vote_ticket_address = nft_vote_ticket_cookies[0].address;
-    let cnft_vote_ticket = nft_voter_test.bench.get_account(&cnft_vote_ticket_address).await;
+    let cnft_action_ticket_address = nft_action_ticket_cookies[0].address;
+    let cnft_action_ticket = nft_voter_test.bench.get_account(&cnft_action_ticket_address).await;
 
-    assert_eq!(None, cnft_vote_ticket);
+    assert_eq!(None, cnft_action_ticket);
 
     Ok(())
 }
@@ -234,7 +234,7 @@ async fn test_cast_nft_vote_with_nft_and_cnft() -> Result<(), TransportError> {
     let clock = nft_voter_test.bench.get_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -249,7 +249,7 @@ async fn test_cast_nft_vote_with_nft_and_cnft() -> Result<(), TransportError> {
             5,
             8
         ).await?;
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -266,7 +266,7 @@ async fn test_cast_nft_vote_with_nft_and_cnft() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]],
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]],
         None
     ).await?;
 
@@ -285,13 +285,13 @@ async fn test_cast_nft_vote_with_nft_and_cnft() -> Result<(), TransportError> {
     assert_eq!(voter_weight_record.weight_action, Some(VoterWeightAction::CastVote.into()));
     assert_eq!(voter_weight_record.weight_action_target, Some(proposal_cookie.address));
 
-    let nft_vote_ticket_address = nft_vote_ticket_cookies[0].address;
-    let nft_vote_ticket = nft_voter_test.bench.get_account(&nft_vote_ticket_address).await;
-    assert_eq!(None, nft_vote_ticket);
+    let nft_action_ticket_address = nft_action_ticket_cookies[0].address;
+    let nft_action_ticket = nft_voter_test.bench.get_account(&nft_action_ticket_address).await;
+    assert_eq!(None, nft_action_ticket);
 
-    let cnft_vote_ticket_address = cnft_vote_ticket_cookies[0].address;
-    let cnft_vote_ticket = nft_voter_test.bench.get_account(&cnft_vote_ticket_address).await;
-    assert_eq!(None, cnft_vote_ticket);
+    let cnft_action_ticket_address = cnft_action_ticket_cookies[0].address;
+    let cnft_action_ticket = nft_voter_test.bench.get_account(&cnft_action_ticket_address).await;
+    assert_eq!(None, cnft_action_ticket);
 
     Ok(())
 }
@@ -343,7 +343,7 @@ async fn test_cast_nft_vote_with_multiple_nfts() -> Result<(), TransportError> {
     let clock = nft_voter_test.bench.get_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -358,7 +358,7 @@ async fn test_cast_nft_vote_with_multiple_nfts() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -377,13 +377,13 @@ async fn test_cast_nft_vote_with_multiple_nfts() -> Result<(), TransportError> {
     assert_eq!(voter_weight_record.weight_action, Some(VoterWeightAction::CastVote.into()));
     assert_eq!(voter_weight_record.weight_action_target, Some(proposal_cookie.address));
 
-    let nft_vote_ticket_address = nft_vote_ticket_cookies[0].address;
-    let nft_vote_ticket = nft_voter_test.bench.get_account(&nft_vote_ticket_address).await;
-    assert_eq!(None, nft_vote_ticket);
+    let nft_action_ticket_address = nft_action_ticket_cookies[0].address;
+    let nft_action_ticket = nft_voter_test.bench.get_account(&nft_action_ticket_address).await;
+    assert_eq!(None, nft_action_ticket);
 
-    let nft_vote_ticket_address2 = nft_vote_ticket_cookies[1].address;
-    let nft_vote_ticket2 = nft_voter_test.bench.get_account(&nft_vote_ticket_address2).await;
-    assert_eq!(None, nft_vote_ticket2);
+    let nft_action_ticket_address2 = nft_action_ticket_cookies[1].address;
+    let nft_action_ticket2 = nft_voter_test.bench.get_account(&nft_action_ticket_address2).await;
+    assert_eq!(None, nft_action_ticket2);
 
     Ok(())
 }
@@ -454,7 +454,7 @@ async fn test_cast_nft_vote_with_multiple_cnfts() -> Result<(), TransportError> 
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -471,7 +471,7 @@ async fn test_cast_nft_vote_with_multiple_cnfts() -> Result<(), TransportError> 
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -562,7 +562,7 @@ async fn test_cast_nft_vote_with_multiple_trees() -> Result<(), TransportError> 
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -579,7 +579,7 @@ async fn test_cast_nft_vote_with_multiple_trees() -> Result<(), TransportError> 
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -675,7 +675,7 @@ async fn test_cast_nft_vote_with_multiple_trees_and_different_size() -> Result<(
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -692,7 +692,7 @@ async fn test_cast_nft_vote_with_multiple_trees_and_different_size() -> Result<(
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -757,7 +757,7 @@ async fn test_cast_nft_vote_with_nft_already_voted_error() -> Result<(), Transpo
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -772,7 +772,7 @@ async fn test_cast_nft_vote_with_nft_already_voted_error() -> Result<(), Transpo
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -786,7 +786,7 @@ async fn test_cast_nft_vote_with_nft_already_voted_error() -> Result<(), Transpo
             &proposal_cookie,
             &voter_cookie,
             &voter_token_owner_record_cookie,
-            &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+            &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
             None
         ).await
         .err()
@@ -848,7 +848,7 @@ async fn test_cast_nft_vote_with_cnft_already_voted_error() -> Result<(), Transp
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -865,7 +865,7 @@ async fn test_cast_nft_vote_with_cnft_already_voted_error() -> Result<(), Transp
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -879,7 +879,7 @@ async fn test_cast_nft_vote_with_cnft_already_voted_error() -> Result<(), Transp
             &proposal_cookie,
             &voter_cookie,
             &voter_token_owner_record_cookie,
-            &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+            &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
             None
         ).await
         .err()
@@ -930,7 +930,7 @@ async fn test_cast_nft_vote_with_nft_invalid_voter_error() -> Result<(), Transpo
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -947,7 +947,7 @@ async fn test_cast_nft_vote_with_nft_invalid_voter_error() -> Result<(), Transpo
             &proposal_cookie,
             &voter_cookie2,
             &voter_token_owner_record_cookie,
-            &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+            &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
             None
         ).await
         .err()
@@ -1006,7 +1006,7 @@ async fn test_cast_nft_vote_with_cnft_invalid_voter_error() -> Result<(), Transp
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1026,7 +1026,7 @@ async fn test_cast_nft_vote_with_cnft_invalid_voter_error() -> Result<(), Transp
             &proposal_cookie,
             &voter_cookie2,
             &voter_token_owner_record_cookie,
-            &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+            &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
             None
         ).await
         .err()
@@ -1076,7 +1076,7 @@ async fn test_cast_nft_vote_with_same_nft_error() -> Result<(), TransportError> 
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1092,7 +1092,7 @@ async fn test_cast_nft_vote_with_same_nft_error() -> Result<(), TransportError> 
             &proposal_cookie,
             &voter_cookie,
             &voter_token_owner_record_cookie,
-            &[&nft_vote_ticket_cookies[0], &nft_vote_ticket_cookies[0]],
+            &[&nft_action_ticket_cookies[0], &nft_action_ticket_cookies[0]],
             None
         ).await
         .err()
@@ -1145,7 +1145,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_nft_attempted_sandw
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1164,7 +1164,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_nft_attempted_sandw
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         Some(args)
     ).await?;
 
@@ -1179,7 +1179,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_nft_attempted_sandw
         &nft_vote_record_cookiess
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1194,7 +1194,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_nft_attempted_sandw
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -1260,7 +1260,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_cnft_attempted_sand
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1281,7 +1281,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_cnft_attempted_sand
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         Some(args)
     ).await?;
 
@@ -1296,7 +1296,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_cnft_attempted_sand
         &nft_vote_record_cookiess
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1313,7 +1313,7 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_cnft_attempted_sand
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -1366,7 +1366,7 @@ async fn test_cast_nft_vote_using_delegate_with_nft() -> Result<(), TransportErr
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1389,7 +1389,7 @@ async fn test_cast_nft_vote_using_delegate_with_nft() -> Result<(), TransportErr
         &proposal_cookie,
         &delegate_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -1451,7 +1451,7 @@ async fn test_cast_nft_vote_using_delegate_with_cnft() -> Result<(), TransportEr
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1476,7 +1476,7 @@ async fn test_cast_nft_vote_using_delegate_with_cnft() -> Result<(), TransportEr
         &proposal_cookie,
         &delegate_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -1537,7 +1537,7 @@ async fn test_cast_nft_vote_with_nft_invalid_voter_weight_token_owner_error() ->
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1553,7 +1553,7 @@ async fn test_cast_nft_vote_with_nft_invalid_voter_weight_token_owner_error() ->
             &proposal_cookie,
             &voter_cookie,
             &voter_token_owner_record_cookie,
-            &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+            &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
             None
         ).await
         .err()
@@ -1622,7 +1622,7 @@ async fn test_cast_nft_vote_with_cnft_invalid_voter_weight_token_owner_error() -
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1640,7 +1640,7 @@ async fn test_cast_nft_vote_with_cnft_invalid_voter_weight_token_owner_error() -
             &proposal_cookie,
             &voter_cookie,
             &voter_token_owner_record_cookie,
-            &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+            &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
             None
         ).await
         .err()
@@ -1703,7 +1703,7 @@ async fn test_cast_nft_vote_with_max_5_nfts() -> Result<(), TransportError> {
     let clock = nft_voter_test.bench.get_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1718,7 +1718,7 @@ async fn test_cast_nft_vote_with_max_5_nfts() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 

--- a/cNft-Governance/governance-program-library/programs/nft-voter/tests/create_cnft_action_ticket.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/tests/create_cnft_action_ticket.rs
@@ -7,7 +7,7 @@ use spl_account_compression::AccountCompressionError;
 mod program_test;
 
 #[tokio::test]
-async fn test_create_cnft_vote_ticket() -> Result<(), TransportError> {
+async fn test_create_cnft_action_ticket() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -51,7 +51,7 @@ async fn test_create_cnft_vote_ticket() -> Result<(), TransportError> {
             8
         ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -61,16 +61,16 @@ async fn test_create_cnft_vote_ticket() -> Result<(), TransportError> {
         &action
     ).await?;
 
-    let cnft_vote_ticket = &cnft_vote_ticket_cookies[0].address;
-    let cnft_vote_ticket_info = nft_voter_test.get_nft_vote_ticket(&cnft_vote_ticket).await;
+    let cnft_action_ticket = &cnft_action_ticket_cookies[0].address;
+    let cnft_action_ticket_info = nft_voter_test.get_nft_action_ticket(&cnft_action_ticket).await;
 
-    assert!(cnft_vote_ticket_info.weight == 3);
+    assert!(cnft_action_ticket_info.weight == 3);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_create_cnft_vote_ticket_with_multiple_nfts() -> Result<(), TransportError> {
+async fn test_create_cnft_action_ticket_with_multiple_nfts() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -128,7 +128,7 @@ async fn test_create_cnft_vote_ticket_with_multiple_nfts() -> Result<(), Transpo
             8
         ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -138,16 +138,16 @@ async fn test_create_cnft_vote_ticket_with_multiple_nfts() -> Result<(), Transpo
         &action
     ).await?;
 
-    let cnft_vote_ticket = &cnft_vote_ticket_cookies[0].address;
-    let cnft_vote_ticket_info = nft_voter_test.get_nft_vote_ticket(&cnft_vote_ticket).await;
+    let cnft_action_ticket = &cnft_action_ticket_cookies[0].address;
+    let cnft_action_ticket_info = nft_voter_test.get_nft_action_ticket(&cnft_action_ticket).await;
 
-    assert!(cnft_vote_ticket_info.weight == 3);
+    assert!(cnft_action_ticket_info.weight == 3);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_create_cnft_vote_ticket_with_unverified_collection_error() -> Result<
+async fn test_create_cnft_action_ticket_with_unverified_collection_error() -> Result<
     (),
     TransportError
 > {
@@ -198,7 +198,7 @@ async fn test_create_cnft_vote_ticket_with_unverified_collection_error() -> Resu
     }
 
     let err = nft_voter_test
-        .with_create_cnft_vote_ticket(
+        .with_create_cnft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -215,7 +215,10 @@ async fn test_create_cnft_vote_ticket_with_unverified_collection_error() -> Resu
 }
 
 #[tokio::test]
-async fn test_create_cnft_vote_ticket_with_invalid_metadata_error() -> Result<(), TransportError> {
+async fn test_create_cnft_action_ticket_with_invalid_metadata_error() -> Result<
+    (),
+    TransportError
+> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -280,7 +283,7 @@ async fn test_create_cnft_vote_ticket_with_invalid_metadata_error() -> Result<()
     };
 
     let err = nft_voter_test
-        .with_create_cnft_vote_ticket(
+        .with_create_cnft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -297,7 +300,7 @@ async fn test_create_cnft_vote_ticket_with_invalid_metadata_error() -> Result<()
 }
 
 #[tokio::test]
-async fn test_create_cnft_vote_ticket_with_invalid_collection_error() -> Result<
+async fn test_create_cnft_action_ticket_with_invalid_collection_error() -> Result<
     (),
     TransportError
 > {
@@ -346,7 +349,7 @@ async fn test_create_cnft_vote_ticket_with_invalid_collection_error() -> Result<
         ).await?;
 
     let err = nft_voter_test
-        .with_create_cnft_vote_ticket(
+        .with_create_cnft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -363,7 +366,7 @@ async fn test_create_cnft_vote_ticket_with_invalid_collection_error() -> Result<
 }
 
 #[tokio::test]
-async fn test_create_cnft_vote_ticket_using_delegate() -> Result<(), TransportError> {
+async fn test_create_cnft_action_ticket_using_delegate() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -421,7 +424,7 @@ async fn test_create_cnft_vote_ticket_using_delegate() -> Result<(), TransportEr
 
     let delegate_signers = &[&delegate_cookie.signer];
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket_using_ix(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket_using_ix(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -435,10 +438,10 @@ async fn test_create_cnft_vote_ticket_using_delegate() -> Result<(), TransportEr
         Some(delegate_signers)
     ).await?;
 
-    let cnft_vote_ticket = &cnft_vote_ticket_cookies[0].address;
-    let cnft_vote_ticket_info = nft_voter_test.get_nft_vote_ticket(&cnft_vote_ticket).await;
+    let cnft_action_ticket = &cnft_action_ticket_cookies[0].address;
+    let cnft_action_ticket_info = nft_voter_test.get_nft_action_ticket(&cnft_action_ticket).await;
 
-    assert!(cnft_vote_ticket_info.weight == 3);
+    assert!(cnft_action_ticket_info.weight == 3);
 
     Ok(())
 }

--- a/cNft-Governance/governance-program-library/programs/nft-voter/tests/create_nft_action_ticket.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/tests/create_nft_action_ticket.rs
@@ -7,7 +7,7 @@ use solana_sdk::transport::TransportError;
 mod program_test;
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket() -> Result<(), TransportError> {
+async fn test_create_nft_action_ticket() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -39,7 +39,7 @@ async fn test_create_nft_vote_ticket() -> Result<(), TransportError> {
         None
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -47,16 +47,16 @@ async fn test_create_nft_vote_ticket() -> Result<(), TransportError> {
         &action
     ).await?;
 
-    let nft_vote_ticket = &nft_vote_ticket_cookies[0].address;
-    let nft_vote_ticket_info = nft_voter_test.get_nft_vote_ticket(&nft_vote_ticket).await;
+    let nft_action_ticket = &nft_action_ticket_cookies[0].address;
+    let nft_action_ticket_info = nft_voter_test.get_nft_action_ticket(&nft_action_ticket).await;
 
-    assert!(nft_vote_ticket_info.weight == 3);
+    assert!(nft_action_ticket_info.weight == 3);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket_with_multiple_nfts() -> Result<(), TransportError> {
+async fn test_create_nft_action_ticket_with_multiple_nfts() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -96,7 +96,7 @@ async fn test_create_nft_vote_ticket_with_multiple_nfts() -> Result<(), Transpor
 
     nft_voter_test.bench.advance_clock().await;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -104,19 +104,19 @@ async fn test_create_nft_vote_ticket_with_multiple_nfts() -> Result<(), Transpor
         &action
     ).await?;
 
-    let cnft_vote_ticket = nft_vote_ticket_cookies[0].address;
-    let cnft_vote_ticket_info = nft_voter_test.get_nft_vote_ticket(&cnft_vote_ticket).await;
-    assert!(cnft_vote_ticket_info.weight == 3);
+    let cnft_action_ticket = nft_action_ticket_cookies[0].address;
+    let cnft_action_ticket_info = nft_voter_test.get_nft_action_ticket(&cnft_action_ticket).await;
+    assert!(cnft_action_ticket_info.weight == 3);
 
-    let cnft_vote_ticket2 = nft_vote_ticket_cookies[1].address;
-    let cnft_vote_ticket_info2 = nft_voter_test.get_nft_vote_ticket(&cnft_vote_ticket2).await;
-    assert!(cnft_vote_ticket_info2.weight == 3);
+    let cnft_action_ticket2 = nft_action_ticket_cookies[1].address;
+    let cnft_action_ticket_info2 = nft_voter_test.get_nft_action_ticket(&cnft_action_ticket2).await;
+    assert!(cnft_action_ticket_info2.weight == 3);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket_with_unverified_collection_error() -> Result<
+async fn test_create_nft_action_ticket_with_unverified_collection_error() -> Result<
     (),
     TransportError
 > {
@@ -155,7 +155,7 @@ async fn test_create_nft_vote_ticket_with_unverified_collection_error() -> Resul
     ).await?;
 
     let err = nft_voter_test
-        .with_create_nft_vote_ticket(
+        .with_create_nft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -170,7 +170,7 @@ async fn test_create_nft_vote_ticket_with_unverified_collection_error() -> Resul
 }
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket_with_invalid_metadata_error() -> Result<(), TransportError> {
+async fn test_create_nft_action_ticket_with_invalid_metadata_error() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -215,7 +215,7 @@ async fn test_create_nft_vote_ticket_with_invalid_metadata_error() -> Result<(),
     nft1_cookie.metadata = nft2_cookie.metadata;
 
     let err = nft_voter_test
-        .with_create_nft_vote_ticket(
+        .with_create_nft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -230,7 +230,10 @@ async fn test_create_nft_vote_ticket_with_invalid_metadata_error() -> Result<(),
 }
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket_with_invalid_collection_error() -> Result<(), TransportError> {
+async fn test_create_nft_action_ticket_with_invalid_collection_error() -> Result<
+    (),
+    TransportError
+> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -265,7 +268,7 @@ async fn test_create_nft_vote_ticket_with_invalid_collection_error() -> Result<(
     ).await?;
 
     let err = nft_voter_test
-        .with_create_nft_vote_ticket(
+        .with_create_nft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -280,7 +283,7 @@ async fn test_create_nft_vote_ticket_with_invalid_collection_error() -> Result<(
 }
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket_with_no_nft_error() -> Result<(), TransportError> {
+async fn test_create_nft_action_ticket_with_no_nft_error() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     // Arrange
     let mut nft_voter_test = NftVoterTest::start_new().await;
@@ -319,7 +322,7 @@ async fn test_create_nft_vote_ticket_with_no_nft_error() -> Result<(), Transport
 
     // Act
     let err = nft_voter_test
-        .with_create_nft_vote_ticket(
+        .with_create_nft_action_ticket(
             &registrar_cookie,
             &voter_weight_record_cookie,
             &voter_cookie,
@@ -334,7 +337,7 @@ async fn test_create_nft_vote_ticket_with_no_nft_error() -> Result<(), Transport
 }
 
 #[tokio::test]
-async fn test_create_nft_vote_ticket_using_delegate() -> Result<(), TransportError> {
+async fn test_create_nft_action_ticket_using_delegate() -> Result<(), TransportError> {
     let action = VoterWeightAction::CastVote;
     let mut nft_voter_test = NftVoterTest::start_new().await;
     let realm_cookie = nft_voter_test.governance.with_realm().await?;
@@ -380,7 +383,7 @@ async fn test_create_nft_vote_ticket_using_delegate() -> Result<(), TransportErr
 
     let delegate_signers = &[&delegate_cookie.signer];
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket_using_ix(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket_using_ix(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -392,10 +395,10 @@ async fn test_create_nft_vote_ticket_using_delegate() -> Result<(), TransportErr
         Some(delegate_signers)
     ).await?;
 
-    let nft_vote_ticket = &nft_vote_ticket_cookies[0].address;
-    let nft_vote_ticket_info = nft_voter_test.get_nft_vote_ticket(&nft_vote_ticket).await;
+    let nft_action_ticket = &nft_action_ticket_cookies[0].address;
+    let nft_action_ticket_info = nft_voter_test.get_nft_action_ticket(&nft_action_ticket).await;
 
-    assert!(nft_vote_ticket_info.weight == 3);
+    assert!(nft_action_ticket_info.weight == 3);
 
     Ok(())
 }

--- a/cNft-Governance/governance-program-library/programs/nft-voter/tests/program_test/nft_voter_test.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/tests/program_test/nft_voter_test.rs
@@ -335,7 +335,7 @@ impl NftVoterTest {
         registrar_cookie: &RegistrarCookie,
         voter_weight_record_cookie: &mut VoterWeightRecordCookie,
         voter_weight_action: VoterWeightAction,
-        nft_vote_ticket_cookies: &[&NftVoteTicketCookie]
+        nft_action_ticket_cookies: &[&NftVoteTicketCookie]
     ) -> Result<(), BanksClientError> {
         let data = anchor_lang::InstructionData::data(
             &(gpl_nft_voter::instruction::UpdateVoterWeightRecord {
@@ -351,9 +351,9 @@ impl NftVoterTest {
 
         let mut account_metas = anchor_lang::ToAccountMetas::to_account_metas(&accounts, None);
 
-        for nft_vote_ticket_cookie in nft_vote_ticket_cookies {
-            let nft_vote_ticket = nft_vote_ticket_cookie.address;
-            account_metas.push(AccountMeta::new(nft_vote_ticket, false));
+        for nft_action_ticket_cookie in nft_action_ticket_cookies {
+            let nft_action_ticket = nft_action_ticket_cookie.address;
+            account_metas.push(AccountMeta::new(nft_action_ticket, false));
         }
 
         let instructions = vec![Instruction {
@@ -494,7 +494,7 @@ impl NftVoterTest {
         proposal_cookie: &ProposalCookie,
         nft_voter_cookie: &WalletCookie,
         voter_token_owner_record_cookie: &TokenOwnerRecordCookie,
-        nft_vote_ticket_cookies: &[&NftVoteTicketCookie],
+        nft_action_ticket_cookies: &[&NftVoteTicketCookie],
         args: Option<CastNftVoteArgs>
     ) -> Result<Vec<NftVoteRecordCookie>, BanksClientError> {
         let args = args.unwrap_or_default();
@@ -516,16 +516,16 @@ impl NftVoterTest {
         let mut account_metas = anchor_lang::ToAccountMetas::to_account_metas(&accounts, None);
         let mut nft_vote_record_cookies = vec![];
 
-        for nft_vote_ticket_cookie in nft_vote_ticket_cookies {
-            let nft_mint = &nft_vote_ticket_cookie.nft_mint;
+        for nft_action_ticket_cookie in nft_action_ticket_cookies {
+            let nft_mint = &nft_action_ticket_cookie.nft_mint;
 
-            let nft_vote_ticket = nft_vote_ticket_cookie.address;
-            let nft_vote_ticket_info = AccountMeta::new(nft_vote_ticket, false);
+            let nft_action_ticket = nft_action_ticket_cookie.address;
+            let nft_action_ticket_info = AccountMeta::new(nft_action_ticket, false);
 
             let nft_vote_record = get_nft_vote_record_address(&proposal_cookie.address, &nft_mint);
             let nft_vote_record_info = AccountMeta::new(nft_vote_record, false);
 
-            account_metas.push(nft_vote_ticket_info);
+            account_metas.push(nft_action_ticket_info);
             account_metas.push(nft_vote_record_info);
 
             let account = NftVoteRecord {
@@ -583,7 +583,7 @@ impl NftVoterTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_create_nft_vote_ticket(
+    pub async fn with_create_nft_action_ticket(
         &mut self,
         registrar_cookie: &RegistrarCookie,
         voter_weight_record_cookie: &VoterWeightRecordCookie,
@@ -591,7 +591,7 @@ impl NftVoterTest {
         nft_cookies: &[&NftCookie],
         action: &VoterWeightAction
     ) -> Result<Vec<NftVoteTicketCookie>, BanksClientError> {
-        self.with_create_nft_vote_ticket_using_ix(
+        self.with_create_nft_action_ticket_using_ix(
             registrar_cookie,
             voter_weight_record_cookie,
             voter_cookie,
@@ -603,7 +603,7 @@ impl NftVoterTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_create_nft_vote_ticket_using_ix<F: Fn(&mut Instruction)>(
+    pub async fn with_create_nft_action_ticket_using_ix<F: Fn(&mut Instruction)>(
         &mut self,
         registrar_cookie: &RegistrarCookie,
         voter_weight_record_cookie: &VoterWeightRecordCookie,
@@ -613,7 +613,7 @@ impl NftVoterTest {
         instruction_override: F,
         signers_override: Option<&[&Keypair]>
     ) -> Result<Vec<NftVoteTicketCookie>, BanksClientError> {
-        let accounts = gpl_nft_voter::accounts::CreateNftVoteTicket {
+        let accounts = gpl_nft_voter::accounts::CreateNftActionTicket {
             registrar: registrar_cookie.address,
             voter_weight_record: voter_weight_record_cookie.address,
             voter_authority: voter_cookie.address,
@@ -622,7 +622,7 @@ impl NftVoterTest {
         };
 
         let data = anchor_lang::InstructionData::data(
-            &(gpl_nft_voter::instruction::CreateNftVoteTicket {
+            &(gpl_nft_voter::instruction::CreateNftActionTicket {
                 voter_weight_action: action.clone(),
             })
         );
@@ -633,10 +633,10 @@ impl NftVoterTest {
             data,
         };
 
-        let mut nft_vote_ticket_cookies = vec![];
+        let mut nft_action_ticket_cookies = vec![];
         let ticket_type = format!("nft-{}-ticket", &action).to_string();
         for nft_cookie in nft_cookies {
-            let nft_vote_ticket = get_nft_vote_ticket_address(
+            let nft_action_ticket = get_nft_action_ticket_address(
                 &ticket_type,
                 &registrar_cookie.address,
                 &voter_cookie.address,
@@ -645,11 +645,11 @@ impl NftVoterTest {
 
             verify_nft_info_ix.accounts.push(AccountMeta::new_readonly(nft_cookie.address, false));
             verify_nft_info_ix.accounts.push(AccountMeta::new_readonly(nft_cookie.metadata, false));
-            verify_nft_info_ix.accounts.push(AccountMeta::new(nft_vote_ticket, false));
+            verify_nft_info_ix.accounts.push(AccountMeta::new(nft_action_ticket, false));
 
-            nft_vote_ticket_cookies.push(NftVoteTicketCookie {
+            nft_action_ticket_cookies.push(NftVoteTicketCookie {
                 nft_mint: nft_cookie.mint_cookie.address.clone(),
-                address: nft_vote_ticket.clone(),
+                address: nft_action_ticket.clone(),
             });
         }
 
@@ -659,11 +659,11 @@ impl NftVoterTest {
 
         self.bench.process_transaction(&[verify_nft_info_ix], Some(signers)).await?;
 
-        Ok(nft_vote_ticket_cookies)
+        Ok(nft_action_ticket_cookies)
     }
 
     #[allow(dead_code)]
-    pub async fn with_create_cnft_vote_ticket(
+    pub async fn with_create_cnft_action_ticket(
         &mut self,
         registrar_cookie: &RegistrarCookie,
         voter_weight_record_cookie: &VoterWeightRecordCookie,
@@ -673,7 +673,7 @@ impl NftVoterTest {
         proofs: &[&Vec<AccountMeta>],
         action: &VoterWeightAction
     ) -> Result<Vec<NftVoteTicketCookie>, BanksClientError> {
-        self.with_create_cnft_vote_ticket_using_ix(
+        self.with_create_cnft_action_ticket_using_ix(
             registrar_cookie,
             voter_weight_record_cookie,
             voter_cookie,
@@ -687,7 +687,7 @@ impl NftVoterTest {
     }
 
     #[allow(dead_code)]
-    pub async fn with_create_cnft_vote_ticket_using_ix<F: Fn(&mut Instruction)>(
+    pub async fn with_create_cnft_action_ticket_using_ix<F: Fn(&mut Instruction)>(
         &mut self,
         registrar_cookie: &RegistrarCookie,
         voter_weight_record_cookie: &VoterWeightRecordCookie,
@@ -705,7 +705,7 @@ impl NftVoterTest {
             .map(|v| v.clone())
             .collect();
 
-        let accounts = gpl_nft_voter::accounts::CreateCnftVoteTicket {
+        let accounts = gpl_nft_voter::accounts::CreateCnftActionTicket {
             registrar: registrar_cookie.address,
             voter_weight_record: voter_weight_record_cookie.address,
             leaf_owner: leaf_cookies[0].owner.pubkey(),
@@ -716,7 +716,7 @@ impl NftVoterTest {
         };
 
         let data = anchor_lang::InstructionData::data(
-            &(gpl_nft_voter::instruction::CreateCnftVoteTicket {
+            &(gpl_nft_voter::instruction::CreateCnftActionTicket {
                 voter_weight_action: action.clone(),
                 params,
             })
@@ -728,7 +728,7 @@ impl NftVoterTest {
             data,
         };
 
-        let mut nft_vote_ticket_cookies = vec![];
+        let mut nft_action_ticket_cookies = vec![];
         let ticket_type = format!("nft-{}-ticket", &action).to_string();
         for i in 0..leaf_verification_cookies.len() {
             let tree_address = leaf_cookies[i].tree_address;
@@ -736,21 +736,21 @@ impl NftVoterTest {
             let proof = &mut proofs[i].clone();
             let asset_id = &leaf_cookies[i].asset_id;
 
-            let cnft_vote_ticket = get_nft_vote_ticket_address(
+            let cnft_action_ticket = get_nft_action_ticket_address(
                 &ticket_type,
                 &registrar_cookie.address,
                 &voter_cookie.address,
                 asset_id
             ).0;
-            let cnft_vote_ticket_info = AccountMeta::new(cnft_vote_ticket, false);
+            let cnft_action_ticket_info = AccountMeta::new(cnft_action_ticket, false);
 
             verify_cnft_info_ix.accounts.push(tree_account_info);
             verify_cnft_info_ix.accounts.append(proof);
-            verify_cnft_info_ix.accounts.push(cnft_vote_ticket_info);
+            verify_cnft_info_ix.accounts.push(cnft_action_ticket_info);
 
-            nft_vote_ticket_cookies.push(NftVoteTicketCookie {
+            nft_action_ticket_cookies.push(NftVoteTicketCookie {
                 nft_mint: asset_id.clone(),
-                address: cnft_vote_ticket.clone(),
+                address: cnft_action_ticket.clone(),
             });
         }
 
@@ -760,7 +760,7 @@ impl NftVoterTest {
 
         self.bench.process_transaction(&[verify_cnft_info_ix], Some(signers)).await?;
 
-        Ok(nft_vote_ticket_cookies)
+        Ok(nft_action_ticket_cookies)
     }
 
     #[allow(dead_code)]
@@ -787,7 +787,7 @@ impl NftVoterTest {
     }
 
     #[allow(dead_code)]
-    pub async fn get_nft_vote_ticket(&mut self, cnft_vote_ticket: &Pubkey) -> NftVoteTicket {
-        self.bench.get_borsh_account::<NftVoteTicket>(cnft_vote_ticket).await
+    pub async fn get_nft_action_ticket(&mut self, cnft_action_ticket: &Pubkey) -> NftActionTicket {
+        self.bench.get_borsh_account::<NftActionTicket>(cnft_action_ticket).await
     }
 }

--- a/cNft-Governance/governance-program-library/programs/nft-voter/tests/relinquish_vote.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/tests/relinquish_vote.rs
@@ -47,7 +47,7 @@ async fn test_relinquish_nft_vote_with_nft() -> Result<(), TransportError> {
         None
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -62,7 +62,7 @@ async fn test_relinquish_nft_vote_with_nft() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -141,7 +141,7 @@ async fn test_relinquish_nft_vote_with_cnft() -> Result<(), TransportError> {
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -158,7 +158,7 @@ async fn test_relinquish_nft_vote_with_cnft() -> Result<(), TransportError> {
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -235,7 +235,7 @@ async fn test_relinquish_nft_vote_with_nft_and_cnft() -> Result<(), TransportErr
         &voter_cookie
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -251,7 +251,7 @@ async fn test_relinquish_nft_vote_with_nft_and_cnft() -> Result<(), TransportErr
             8
         ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -268,7 +268,7 @@ async fn test_relinquish_nft_vote_with_nft_and_cnft() -> Result<(), TransportErr
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]],
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]],
         None
     ).await?;
 
@@ -337,7 +337,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_with_nft() -> Res
         None
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -352,7 +352,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_with_nft() -> Res
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -435,7 +435,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_with_cnft() -> Re
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -452,7 +452,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_with_cnft() -> Re
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -525,7 +525,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_and_vote_record_e
         None
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -540,7 +540,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_and_vote_record_e
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -608,7 +608,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_and_vote_record_e
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -625,7 +625,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_and_vote_record_e
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>(),
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>(),
         None
     ).await?;
 
@@ -687,7 +687,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_error() -> Result<(), Trans
         &voter_cookie
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -703,7 +703,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_error() -> Result<(), Trans
             8
         ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -720,7 +720,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_error() -> Result<(), Trans
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]],
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]],
         None
     ).await?;
 
@@ -793,7 +793,7 @@ async fn test_relinquish_nft_vote_unexpired_vote_weight_record() -> Result<(), T
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -801,7 +801,7 @@ async fn test_relinquish_nft_vote_unexpired_vote_weight_record() -> Result<(), T
         &action
     ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -822,7 +822,7 @@ async fn test_relinquish_nft_vote_unexpired_vote_weight_record() -> Result<(), T
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]],
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]],
         Some(args)
     ).await?;
 
@@ -895,7 +895,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_weight_token_owner_error() 
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -903,7 +903,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_weight_token_owner_error() 
         &action
     ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -920,7 +920,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_weight_token_owner_error() 
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]],
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]],
         None
     ).await?;
 
@@ -989,7 +989,7 @@ async fn test_relinquish_nft_vote_using_delegate() -> Result<(), TransportError>
         &voter_cookie
     ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1005,7 +1005,7 @@ async fn test_relinquish_nft_vote_using_delegate() -> Result<(), TransportError>
             8
         ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -1022,7 +1022,7 @@ async fn test_relinquish_nft_vote_using_delegate() -> Result<(), TransportError>
         &proposal_cookie,
         &voter_cookie,
         &voter_token_owner_record_cookie,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]],
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]],
         None
     ).await?;
 

--- a/cNft-Governance/governance-program-library/programs/nft-voter/tests/update_voter_weight_record.rs
+++ b/cNft-Governance/governance-program-library/programs/nft-voter/tests/update_voter_weight_record.rs
@@ -39,9 +39,9 @@ async fn test_update_voter_weight_record_with_nft() -> Result<(), TransportError
 
     nft_voter_test.bench.advance_clock().await;
     let clock = nft_voter_test.bench.get_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateProposal;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -52,8 +52,8 @@ async fn test_update_voter_weight_record_with_nft() -> Result<(), TransportError
     nft_voter_test.update_voter_weight_record(
         &registrar_cookie,
         &mut voter_weight_record_cookie,
-        VoterWeightAction::CreateProposal,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>()
+        action,
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>()
     ).await?;
 
     let voter_weight_record = nft_voter_test.get_voter_weight_record(
@@ -105,7 +105,7 @@ async fn test_update_voter_weight_record_with_cnft() -> Result<(), TransportErro
 
     nft_voter_test.bench.advance_clock().await;
     let clock = nft_voter_test.bench.get_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateProposal;
 
     let (leaf_verification_cookie, proofs, _) =
         nft_voter_test.merkle_tree.get_leaf_verification_info(
@@ -115,7 +115,7 @@ async fn test_update_voter_weight_record_with_cnft() -> Result<(), TransportErro
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -128,8 +128,8 @@ async fn test_update_voter_weight_record_with_cnft() -> Result<(), TransportErro
     nft_voter_test.update_voter_weight_record(
         &registrar_cookie,
         &mut voter_weight_record_cookie,
-        VoterWeightAction::CreateProposal,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>()
+        action,
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>()
     ).await?;
 
     let voter_weight_record = nft_voter_test.get_voter_weight_record(
@@ -186,7 +186,7 @@ async fn test_update_voter_weight_record_with_nft_and_cnft() -> Result<(), Trans
 
     nft_voter_test.bench.advance_clock().await;
     let clock = nft_voter_test.bench.get_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateProposal;
 
     let (leaf_verification_cookie, proofs, _) =
         nft_voter_test.merkle_tree.get_leaf_verification_info(
@@ -196,7 +196,7 @@ async fn test_update_voter_weight_record_with_nft_and_cnft() -> Result<(), Trans
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -204,7 +204,7 @@ async fn test_update_voter_weight_record_with_nft_and_cnft() -> Result<(), Trans
         &action
     ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -217,8 +217,8 @@ async fn test_update_voter_weight_record_with_nft_and_cnft() -> Result<(), Trans
     nft_voter_test.update_voter_weight_record(
         &registrar_cookie,
         &mut voter_weight_record_cookie,
-        VoterWeightAction::CreateProposal,
-        &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]]
+        action,
+        &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]]
     ).await?;
 
     let voter_weight_record = nft_voter_test.get_voter_weight_record(
@@ -273,9 +273,9 @@ async fn test_update_voter_weight_record_with_multiple_nfts() -> Result<(), Tran
 
     nft_voter_test.bench.advance_clock().await;
     let clock = nft_voter_test.bench.get_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateProposal;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -286,8 +286,8 @@ async fn test_update_voter_weight_record_with_multiple_nfts() -> Result<(), Tran
     nft_voter_test.update_voter_weight_record(
         &registrar_cookie,
         &mut voter_weight_record_cookie,
-        VoterWeightAction::CreateProposal,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>()
+        action,
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>()
     ).await?;
 
     let voter_weight_record = nft_voter_test.get_voter_weight_record(
@@ -345,7 +345,7 @@ async fn test_update_voter_weight_record_with_multiple_cnfts() -> Result<(), Tra
 
     nft_voter_test.bench.advance_clock().await;
     let clock = nft_voter_test.bench.get_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateProposal;
 
     let (leaf_verification_cookie1, proofs1, _) =
         nft_voter_test.merkle_tree.get_leaf_verification_info(
@@ -363,7 +363,7 @@ async fn test_update_voter_weight_record_with_multiple_cnfts() -> Result<(), Tra
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -376,8 +376,8 @@ async fn test_update_voter_weight_record_with_multiple_cnfts() -> Result<(), Tra
     nft_voter_test.update_voter_weight_record(
         &registrar_cookie,
         &mut voter_weight_record_cookie,
-        VoterWeightAction::CreateProposal,
-        &nft_vote_ticket_cookies.iter().collect::<Vec<_>>()
+        action,
+        &nft_action_ticket_cookies.iter().collect::<Vec<_>>()
     ).await?;
 
     let voter_weight_record = nft_voter_test.get_voter_weight_record(
@@ -435,7 +435,7 @@ async fn test_update_voter_weight_with_cast_vote_not_allowed_error() -> Result<(
     nft_voter_test.bench.advance_clock().await;
     let action = VoterWeightAction::CastVote;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -451,7 +451,7 @@ async fn test_update_voter_weight_with_cast_vote_not_allowed_error() -> Result<(
             8
         ).await?;
 
-    let cnft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let cnft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -466,7 +466,7 @@ async fn test_update_voter_weight_with_cast_vote_not_allowed_error() -> Result<(
             &registrar_cookie,
             &mut voter_weight_record_cookie,
             VoterWeightAction::CastVote,
-            &[&nft_vote_ticket_cookies[0], &cnft_vote_ticket_cookies[0]]
+            &[&nft_action_ticket_cookies[0], &cnft_action_ticket_cookies[0]]
         ).await
         .err()
         .unwrap();
@@ -509,9 +509,9 @@ async fn test_update_voter_weight_with_same_nft_error() -> Result<(), TransportE
     ).await?;
 
     nft_voter_test.bench.advance_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateGovernance;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_nft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_nft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -523,8 +523,8 @@ async fn test_update_voter_weight_with_same_nft_error() -> Result<(), TransportE
         .update_voter_weight_record(
             &registrar_cookie,
             &mut voter_weight_record_cookie,
-            VoterWeightAction::CreateGovernance,
-            &[&nft_vote_ticket_cookies[0], &nft_vote_ticket_cookies[0]]
+            action,
+            &[&nft_action_ticket_cookies[0], &nft_action_ticket_cookies[0]]
         ).await
         .err()
         .unwrap();
@@ -568,7 +568,7 @@ async fn test_update_voter_weight_with_same_cnft_error() -> Result<(), Transport
     ).await?;
 
     nft_voter_test.bench.advance_clock().await;
-    let action = VoterWeightAction::CastVote;
+    let action = VoterWeightAction::CreateProposal;
 
     let (leaf_verification_cookie, proofs, _) =
         nft_voter_test.merkle_tree.get_leaf_verification_info(
@@ -578,7 +578,7 @@ async fn test_update_voter_weight_with_same_cnft_error() -> Result<(), Transport
             8
         ).await?;
 
-    let nft_vote_ticket_cookies = nft_voter_test.with_create_cnft_vote_ticket(
+    let nft_action_ticket_cookies = nft_voter_test.with_create_cnft_action_ticket(
         &registrar_cookie,
         &voter_weight_record_cookie,
         &voter_cookie,
@@ -592,8 +592,8 @@ async fn test_update_voter_weight_with_same_cnft_error() -> Result<(), Transport
         .update_voter_weight_record(
             &registrar_cookie,
             &mut voter_weight_record_cookie,
-            VoterWeightAction::CreateGovernance,
-            &[&nft_vote_ticket_cookies[0], &nft_vote_ticket_cookies[0]]
+            action,
+            &[&nft_action_ticket_cookies[0], &nft_action_ticket_cookies[0]]
         ).await
         .err()
         .unwrap();


### PR DESCRIPTION
add time expiry to every ticket to prevent that the govern_token_owner can use the ticket whenever he wants to even if he transfer the NFT. Add an expiration can force the owner use it asap.